### PR TITLE
Don't add state icons for non-light lights

### DIFF
--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -265,7 +265,7 @@ public class Controller {
        List<HomePieceOfFurniture> homeAssistantEntities = new ArrayList<HomePieceOfFurniture>();
 
         for (HomePieceOfFurniture piece : home.getFurniture()) {
-            if (!isHomeAssistantEntity(piece.getName()) || !piece.isVisible())
+            if (!isHomeAssistantEntity(piece.getName()) || !piece.isVisible() || piece instanceof HomeLight)
                 continue;
             homeAssistantEntities.add(piece);
         }


### PR DESCRIPTION
This is to handle the case where the HA light entity doesn't start with `light.` but it a `switch.` or something similar.