### PR TITLE
Use middle of furniture as location for state icon

### DIFF
--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -474,7 +474,7 @@ public class Controller {
     }
 
     private Point2d getFurniture2dLocation(HomePieceOfFurniture piece) {
-        Vector4d objectPosition = new Vector4d(piece.getX(), piece.getElevation(), piece.getY(), 0);
+        Vector4d objectPosition = new Vector4d(piece.getX(), ((piece.getElevation() * 2) + piece.getHeight()) / 2, piece.getY(), 0);
 
         objectPosition.sub(cameraPosition);
         perspectiveTransform.transform(objectPosition);


### PR DESCRIPTION
This is opposed to the bottom of it, ignoring the furniture height.