### PR TITLE
feat: block plugin if project is not open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dl/
 *.swp
 *.swo
 tags
+build*

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ dl/
 *.swp
 *.swo
 tags
-build*

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/ApplicationPlugin.properties
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/ApplicationPlugin.properties
@@ -10,6 +10,9 @@ javaMinimumVersion=1.5
 HomeAssistantFloorPlan.Plugin.NAME=Home Assistant Floor Plan
 HomeAssistantFloorPlan.Plugin.MENU=Tools
 
+HomeAssistantFloorPlan.Panel.error.title=Error
+HomeAssistantFloorPlan.Panel.error.emptyProject.text=No project is open. Please open a project before proceeding.
+
 HomeAssistantFloorPlan.Panel.detectedLightsTreeLabel.text=Detected lights:
 HomeAssistantFloorPlan.Panel.detectedLightsTree.root.text=Light Groups
 

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -166,6 +166,10 @@ public class Controller {
         this.quality = quality;
     }
 
+    public boolean isProjectEmpty() {
+        return home == null || home.getFurniture().isEmpty();
+    }
+
     public void render() throws Exception {
         propertyChangeSupport.firePropertyChange(Property.COMPLETED_RENDERS.name(), numberOfCompletedRenders, 0);
         numberOfCompletedRenders = 0;

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Panel.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Panel.java
@@ -389,6 +389,11 @@ public class Panel extends JPanel implements DialogView {
     }
 
     public void displayView(View parentView) {
+        // Check if a project is open
+        if (controller.isProjectEmpty()) {
+            JOptionPane.showMessageDialog(null, "No project is open. Please open a project before proceeding.", "Error", JOptionPane.ERROR_MESSAGE);
+            return;
+        }
         if (currentPanel == this) {
             SwingUtilities.getWindowAncestor(Panel.this).toFront();
             return;

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Panel.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Panel.java
@@ -389,9 +389,9 @@ public class Panel extends JPanel implements DialogView {
     }
 
     public void displayView(View parentView) {
-        // Check if a project is open
         if (controller.isProjectEmpty()) {
-            JOptionPane.showMessageDialog(null, "No project is open. Please open a project before proceeding.", "Error", JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(null, resource.getString("HomeAssistantFloorPlan.Panel.error.emptyProject.text"),
+                resource.getString("HomeAssistantFloorPlan.Panel.error.title"), JOptionPane.ERROR_MESSAGE);
             return;
         }
         if (currentPanel == this) {


### PR DESCRIPTION
Added:

Plugin will not open until user has opened a project on SH3D, that way we can prevent errors and streamlining the user workflow:

![image](https://github.com/user-attachments/assets/6f295c52-9889-47dd-8f75-4da8d2eae9f2)

This also uses a function suggested by @shmuelzon on #41.
