### PR TITLE
Onboarding Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Ignore .git directory
+.github/
+.vim/
+
+# Ignore build artifacts
+build/
+
+# Ignore downloaded dependencies (these will be re-downloaded in the container)
+dl/
+
+# Ignore documentation
+doc/
+
+# General ignores
+*.swp
+*.swo
+tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use an official OpenJDK runtime as a parent image
+FROM openjdk:8
+
+# Install make, wget, and gettext (for envsubst)
+RUN apt-get update && apt-get install -y \
+    make \
+    wget \
+    gettext
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the project files into the container
+COPY . /app
+
+# Run the Makefile to download dependencies and build the project
+RUN make build
+
+# Command to run when the container starts (optional)
+CMD ["java", "-jar", "dl/SweetHome3D-7.4.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  plugin-builder:
+    image: home-assistant-floor-plan
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/app
+    entrypoint: ["make"]


### PR DESCRIPTION
### Description

This project can use and be leveraged by Docker to manage the build environment. Using Docker ensures that the build process is consistent and isolated from the host machine, avoiding issues related to different operating systems and environments.

Using Docker Compose is a great way to manage your Docker configurations and run commands in a platform-independent way. Also, this approach makes it easier to manage your Docker setup and avoids platform-specific command issues. You can use the same docker-compose.yml file across different environments (Windows, macOS, Linux) without needing to modify the volume mount command.

### How Has This Been Tested?

Run the command below that you will be able to build the project just fine:

- `docker-compose run --rm plugin-builder build`

In the `build` keyword, it can be replaced and used any command specified in this list [How to contribute](https://github.com/shmuelzon/home-assistant-floor-plan/blob/master/CONTRIBUTING.md#on-nix-systems)

### Checklist

* [X] I have tested and built the changes locally and they work as expected
* [ ] I have added relevant documentation or updated existing documentation
* [X] My changes generate no new warnings

### Screenshots (if applicable)

Project cloned:

![image](https://github.com/user-attachments/assets/38cdf5d6-b9e0-4c3e-8554-c92f4e121ac6)

After project built from Docker:

![image](https://github.com/user-attachments/assets/cca8143a-99e7-43f8-bfc2-01801e455429)

### Additional Context

**I will add relevant documentation in another PR.**

### Log

```
[+] Creating 1/0
 ✔ Network home-assistant-floor-plan_default  Created                                                                                                                                              0.0s 
mkdir -p build/com/shmuelzon/HomeAssistantFloorPlan/
envsubst < src/com/shmuelzon/HomeAssistantFloorPlan/ApplicationPlugin.properties > build/com/shmuelzon/HomeAssistantFloorPlan/ApplicationPlugin.properties
Downloading SweetHome3D-7.4.jar
dl/SweetHome3D-7.4.jar                            100%[=============================================================================================================>]  45.24M  13.4MB/s    in 3.4s    
Downloading j3dcore.jar
dl/j3dcore.jar                                    100%[=============================================================================================================>]   2.71M  2.31MB/s    in 1.2s    
Downloading vecmath.jar
dl/vecmath.jar                                    100%[=============================================================================================================>] 306.99K   482KB/s    in 0.6s    
javac -classpath "dl/*:src" -target 1.5 -source 1.5 -d build src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
warning: [options] bootstrap class path not set in conjunction with -source 1.5
warning: [options] source value 1.5 is obsolete and will be removed in a future release
warning: [options] target value 1.5 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
4 warnings
javac -classpath "dl/*:src" -target 1.5 -source 1.5 -d build src/com/shmuelzon/HomeAssistantFloorPlan/Panel.java
warning: [options] bootstrap class path not set in conjunction with -source 1.5
warning: [options] source value 1.5 is obsolete and will be removed in a future release
warning: [options] target value 1.5 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
4 warnings
javac -classpath "dl/*:src" -target 1.5 -source 1.5 -d build src/com/shmuelzon/HomeAssistantFloorPlan/Plugin.java
warning: [options] bootstrap class path not set in conjunction with -source 1.5
warning: [options] source value 1.5 is obsolete and will be removed in a future release
warning: [options] target value 1.5 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
4 warnings
jar -cf HomeAssistantFloorPlanPlugin-45146f0.sh3p -C build .
```
