### PR TITLE
Add cursor on nodes from Panel

### DIFF
--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Panel.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Panel.java
@@ -2,21 +2,19 @@ package com.shmuelzon.HomeAssistantFloorPlan;
 
 import java.awt.Component;
 import java.awt.ComponentOrientation;
+import java.awt.Cursor;
 import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.awt.Cursor;
-import java.awt.Font;
-import java.awt.event.MouseEvent;
-import java.awt.Dimension;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
@@ -57,7 +55,6 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.TreePath;
-import javax.swing.tree.TreeCellRenderer;
 
 import com.eteks.sweethome3d.model.HomeLight;
 import com.eteks.sweethome3d.model.UserPreferences;
@@ -198,19 +195,15 @@ public class Panel extends JPanel implements DialogView {
                 }
             }
         };
-
         detectedLightsTree.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent event) {
-                if (event.getClickCount() != 2)
-                    return;
-
                 TreePath selectedPath = detectedLightsTree.getSelectionPath();
                 if (selectedPath == null)
                     return;
 
                 DefaultMutableTreeNode node = (DefaultMutableTreeNode)selectedPath.getLastPathComponent();
-                if (!node.isLeaf() || !(node.getUserObject() instanceof EntityNode)) {
-                    /* Do nothing if not a leaf or not an EntityNode */
+                if (!node.isLeaf()) {
+                    detectedLightsTree.clearSelection();
                     return;
                 }
 
@@ -218,13 +211,12 @@ public class Panel extends JPanel implements DialogView {
                 openEntityOptionsPanel(entityNode.name);
             }
         });
-
-        /* Handling mouse movement to change cursor */
         detectedLightsTree.addMouseMotionListener(new java.awt.event.MouseMotionAdapter() {
             @Override
             public void mouseMoved(MouseEvent e) {
                 TreePath path = detectedLightsTree.getPathForLocation(e.getX(), e.getY());
-                if (path != null) {
+
+                if (path != null && ((DefaultMutableTreeNode)path.getLastPathComponent()).isLeaf()) {
                     detectedLightsTree.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
                     detectedLightsTree.setSelectionPath(path);
                 } else {
@@ -233,7 +225,6 @@ public class Panel extends JPanel implements DialogView {
                 }
             }
         });
-
         buildLightsGroupsTree(lightsGroups);
         controller.addPropertyChangeListener(Controller.Property.NUMBER_OF_RENDERS, new PropertyChangeListener() {
             public void propertyChange(PropertyChangeEvent ev) {
@@ -249,10 +240,10 @@ public class Panel extends JPanel implements DialogView {
                 return false;
             }
         });
-        DefaultTreeCellRenderer defaultRenderer = (DefaultTreeCellRenderer)detectedLightsTree.getCellRenderer();
-        defaultRenderer.setLeafIcon(null);
-        defaultRenderer.setOpenIcon(null);
-        defaultRenderer.setClosedIcon(null);
+        DefaultTreeCellRenderer renderer = (DefaultTreeCellRenderer)detectedLightsTree.getCellRenderer();
+        renderer.setLeafIcon(null);
+        renderer.setOpenIcon(null);
+        renderer.setClosedIcon(null);
         detectedLightsTree.setBorder(LineBorder.createGrayLineBorder());
 
         widthLabel = new JLabel();

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Panel.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Panel.java
@@ -199,44 +199,6 @@ public class Panel extends JPanel implements DialogView {
             }
         };
 
-        /* Custom renderer to make the text bold when hovering on leaf nodes (entities) */
-        DefaultTreeCellRenderer renderer = new DefaultTreeCellRenderer() {
-            private Font originalFont;
-            private Font boldFont;
-
-            @Override
-            public Component getTreeCellRendererComponent(JTree tree, Object value, boolean selected, boolean expanded, boolean leaf, int row, boolean hasFocus) {
-                JLabel label = (JLabel) super.getTreeCellRendererComponent(tree, value, selected, expanded, leaf, row, hasFocus);
-
-                /* Apply custom styling only to leaf nodes (entities) */
-                if (leaf) {
-                    if (originalFont == null) {
-                        originalFont = label.getFont();
-                        boldFont = originalFont.deriveFont(Font.BOLD);
-                    }
-
-                    if (tree.getSelectionPath() != null && tree.getSelectionPath().equals(tree.getPathForRow(row))) {
-                        label.setFont(boldFont);
-                    } else {
-                        label.setFont(originalFont);
-                    }
-
-                    if (selected) {
-                        /* Avoid background color change */
-                        label.setBackground(tree.getBackground());
-                    }
-
-                    /* Ensure label preferred size can accommodate the full text */
-                    label.setPreferredSize(new Dimension(label.getPreferredSize().width + 20, label.getPreferredSize().height));
-                } else {
-                    /* Reset to original font for non-leaf nodes (groups) */
-                    label.setFont(originalFont);
-                }
-
-                return label;
-            }
-        };
-
         detectedLightsTree.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent event) {
                 if (event.getClickCount() != 2)


### PR DESCRIPTION
### Description

Adding cursor on each node from Panel (tree), to improve UX when hovering each entity.

### How Has This Been Tested?

Open the panel and hover on each entity.

### Checklist

* [X] I have tested and built the changes locally and they work as expected
* [X] I have added relevant documentation or updated existing documentation
* [X] My changes generate no new warnings

### Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/be8f912e-f0a9-4101-8093-ae0d567335ae)

### Additional Context

@shmuelzon can you please check and review if code if closer to what we wanted to achieve please?
I think a better usability of this feature would be to apply only to entities, but I wasn't able to ignore the group itselft. Can you help please? Check image below:

![image](https://github.com/user-attachments/assets/89fbedf9-9261-4772-838f-959b0c849ed1)
