### PR TITLE
Adding more HA entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,11 @@ that allow you to customize the entity according to your needs.
   * `climate.xxx`
   * `cover.xxx`
   * `fan.xxx`
+  * `input_boolean.xxx`
   * `media_player.xxx`
   * `sensor.xxx`
   * `switch.xxx`
+  * `vacuum.xxx`
 
 ## Suggestions
 

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -419,9 +419,11 @@ public class Controller {
             "climate.",
             "cover.",
             "fan.",
+            "input_boolean.",
             "media_player.",
             "sensor.",
             "switch.",
+            "vacuum.",
         };
 
         if (name == null)


### PR DESCRIPTION
### Description

I have a lot of devices, and these HA entities is missing from plugin:

- `input_boolean.xxx`
- `vacuum.xxx`

Why do I need `input_boolean`? This is my use case:

This is my real window + covers. If you notice my windows opens side to side, so I can not close cover 1 (the one is open) because it would break, because of window is opened:

![image](https://github.com/user-attachments/assets/c067ab64-65a7-40eb-80e3-41456fb0d597)

So I had to create an automation, that checks a sensor if that window is closed before closing the cover. So in that case, I cannot use `cover.xxx`, because it would not trigger this automation. I had to create an `input_boolean` to do the checking and then close the cover.

### How Has This Been Tested?

I have created a plugin version and generated the YAML file.

### Checklist

* [X] I have tested and built the changes locally and they work as expected
* [X] I have added relevant documentation or updated existing documentation
* [X] My changes generate no new warnings

### Screenshots (if applicable)

It is in the description.

### Additional Context

N/A
