### PR TITLE
Take into consideration the elevation of the level

### DIFF
--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -743,7 +743,8 @@ public class Controller {
     }
 
     private Point2d getFurniture2dLocation(HomePieceOfFurniture piece) {
-        Vector4d objectPosition = new Vector4d(piece.getX(), ((piece.getElevation() * 2) + piece.getHeight()) / 2, piece.getY(), 0);
+        float levelOffset = piece.getLevel() != null ? piece.getLevel().getElevation() : 0;
+        Vector4d objectPosition = new Vector4d(piece.getX(), (((piece.getElevation() * 2) + piece.getHeight()) / 2) + levelOffset, piece.getY(), 0);
 
         objectPosition.sub(cameraPosition);
         perspectiveTransform.transform(objectPosition);


### PR DESCRIPTION
Each piece of furniture in SH3D has it's position in 3D space including its elevation. That the elevation is relative to the floor of the level it's placed in.
When calculating the 2D-projected location of an entity we observe the building in 3D space with all of its levels so it wasn't enough to use the relative elevation of the entity but we need to offset it with the elevation of the entire floor.

Fixes #82, for real (I hope)