### PR TITLE
Fix NaN positions of entities.

### DIFF
--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -991,7 +991,7 @@ public class Controller {
     private void moveEntityIconsToAvoidIntersection() {
         for (int i = 0; i < 100; i++) {
             List<Set<Entity>> intersectingStateIcons = findIntersectingStateIcons();
-            if (intersectingStateIcons.size() == 0)
+            if (intersectingStateIcons.isEmpty())
                 break;
             for (Set<Entity> set : intersectingStateIcons)
                 separateStateIcons(set);

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -151,6 +151,14 @@ public class Controller {
 
             stateIconMargin = originalMargin;
         }
+
+        public void move(Vector2d direction) {
+            for (Entity entity : this.entities) {
+                entity.position.add(direction);
+            }
+
+            this.position.add(direction);
+        }
     }
 
     public Controller(Home home) {

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -962,14 +962,30 @@ public class Controller {
     private void separateStateIcons(Set<Entity> entities) {
         final double STEP_SIZE = 2.0;
 
-        Point2d centerPostition = getCenterOfStateIcons(entities);
-
-        for (Entity entity : entities) {
-            Vector2d direction = new Vector2d(entity.position.x - centerPostition.x, entity.position.y - centerPostition.y);
-            direction.normalize();
-            direction.scale(STEP_SIZE);
-            entity.position.add(direction);
+        if (entities.isEmpty()) {
+            return;
         }
+
+        Entity entityToMove = entities.iterator().next();
+        // Round position-values because the entity's stored position can differ fractionally from the position in SH3D.
+        entityToMove.position.set(Math.round(entityToMove.position.x), Math.round(entityToMove.position.y));
+
+        Point2d centerPosition = getCenterOfStateIcons(entities);
+
+        Vector2d direction = new Vector2d(
+                entityToMove.position.x - centerPosition.x,
+                entityToMove.position.y - centerPosition.y
+        );
+
+        // Set the direction of the entity's movement to straight-right if it matches the center-position.
+        if (direction.length() == 0) {
+            direction.set(1, 0);
+        }
+
+        // Move the entity's position.
+        direction.normalize();
+        direction.scale(STEP_SIZE);
+        entityToMove.position.add(direction);
     }
 
     private void moveEntityIconsToAvoidIntersection() {

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -1044,20 +1044,26 @@ public class Controller {
 
         Point2d centerPosition = getCenterOfStateIcons(entities);
 
-        Vector2d direction = new Vector2d(
-                entityToMove.position.x - centerPosition.x,
-                entityToMove.position.y - centerPosition.y
-        );
+        for (Entity entity : entities) {
+            Vector2d direction = new Vector2d(
+                    entity.position.x - centerPosition.x,
+                    entity.position.y - centerPosition.y
+            );
 
-        // Set the direction of the entity's movement to straight-right if it matches the center-position.
-        if (direction.length() == 0) {
-            direction.set(1, 0);
+            if (direction.length() == 0) {
+                continue;
+            }
+
+            direction.normalize();
+            direction.scale(STEP_SIZE);
+
+            if (entity instanceof ClusterEntity) {
+                ((ClusterEntity) entity).move(direction);
+                continue;
+            }
+
+            entity.position.add(direction);
         }
-
-        // Move the entity's position.
-        direction.normalize();
-        direction.scale(STEP_SIZE);
-        entityToMove.position.add(direction);
     }
 
     private void moveEntityIconsToAvoidIntersection() {

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -949,8 +949,12 @@ public class Controller {
 
     private Point2d getCenterOfStateIcons(Set<Entity> entities) {
         Point2d centerPosition = new Point2d();
-        for (Entity entity : entities )
+
+        for (Entity entity : entities ) {
+            // Round position-values because the entity's stored position can differ fractionally from the position in SH3D.
+            entity.position.set(Math.round(entity.position.x), Math.round(entity.position.y));
             centerPosition.add(entity.position);
+        }
         centerPosition.scale(1.0 / entities.size());
         return centerPosition;
     }

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -951,8 +951,6 @@ public class Controller {
         Point2d centerPosition = new Point2d();
 
         for (Entity entity : entities ) {
-            // Round position-values because the entity's stored position can differ fractionally from the position in SH3D.
-            entity.position.set(Math.round(entity.position.x), Math.round(entity.position.y));
             centerPosition.add(entity.position);
         }
         centerPosition.scale(1.0 / entities.size());
@@ -965,10 +963,6 @@ public class Controller {
         if (entities.isEmpty()) {
             return;
         }
-
-        Entity entityToMove = entities.iterator().next();
-        // Round position-values because the entity's stored position can differ fractionally from the position in SH3D.
-        entityToMove.position.set(Math.round(entityToMove.position.x), Math.round(entityToMove.position.y));
 
         Point2d centerPosition = getCenterOfStateIcons(entities);
 

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -959,8 +959,8 @@ public class Controller {
         return null;
     }
 
-    private Entity stateIconWithWhichStateIconIntersects(Entity entity) {
-        for (Entity other : homeAssistantEntities.values()) {
+    private Entity stateIconWithWhichStateIconIntersects(Entity entity, Collection<? extends Entity> entities) {
+        for (Entity other : entities) {
             if (entity == other)
                 continue;
             if (doStateIconsIntersect(entity, other))
@@ -969,19 +969,21 @@ public class Controller {
         return null;
     }
 
-    private List<Set<Entity>> findIntersectingStateIcons() {
-        List<Set<Entity>> intersectingStateIcons = new ArrayList<Set<Entity>>();
+    private List<Set<Entity>> findIntersectingStateIcons(Collection<? extends Entity> entities) {
+        List<Set<Entity>> intersectingStateIcons = new ArrayList<>();
 
-        for (Entity entity : homeAssistantEntities.values()) {
+        for (Entity entity : entities) {
             Set<Entity> intersectingSet = setWithWhichStateIconIntersects(entity, intersectingStateIcons);
             if (intersectingSet != null) {
                 intersectingSet.add(entity);
                 continue;
             }
-            Entity intersectingStateIcon = stateIconWithWhichStateIconIntersects(entity);
+
+            Entity intersectingStateIcon = stateIconWithWhichStateIconIntersects(entity, entities);
             if (intersectingStateIcon == null)
                 continue;
-            Set<Entity> intersectingGroup = new HashSet<Entity>();
+
+            Set<Entity> intersectingGroup = new HashSet<>();
             intersectingGroup.add(entity);
             intersectingGroup.add(intersectingStateIcon);
             intersectingStateIcons.add(intersectingGroup);

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -890,11 +890,11 @@ public class Controller {
     }
 
     private boolean doStateIconsIntersect(Entity first, Entity second) {
-        final double STATE_ICON_RAIDUS_INCLUDING_MARGIN = 25.0;
+        final double STATE_ICON_RADIUS_INCLUDING_MARGIN = 20.0;
 
         double x = Math.pow(first.position.x - second.position.x, 2) + Math.pow(first.position.y - second.position.y, 2);
 
-        return x <= Math.pow(STATE_ICON_RAIDUS_INCLUDING_MARGIN * 2, 2);
+        return x <= Math.pow(STATE_ICON_RADIUS_INCLUDING_MARGIN * 2, 2);
     }
 
     private boolean doesStateIconIntersectWithSet(Entity entity, Set<Entity> entities) {

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -1002,6 +1002,31 @@ public class Controller {
         return centerPosition;
     }
 
+    List<ClusterEntity> clusterEntities(Collection<Entity> entities) {
+        List<Entity> unclusteredEntities = new ArrayList<>(entities);
+        List<ClusterEntity> clusters = new ArrayList<>();
+
+        int originalMargin = stateIconMargin;
+        stateIconMargin = -39;
+
+        List<Set<Entity>> intersectingEntities = findIntersectingStateIcons(entities);
+
+        for (Set<Entity> set : intersectingEntities) {
+            clusters.add(new ClusterEntity(set));
+            unclusteredEntities.removeAll(set);
+        }
+
+        for (Entity entity : unclusteredEntities) {
+            Set<Entity> set = new HashSet<>();
+            set.add(entity);
+            clusters.add(new ClusterEntity(set));
+        }
+
+        stateIconMargin = originalMargin;
+
+        return clusters;
+    }
+
     private void separateStateIcons(Set<? extends Entity> entities) {
         final double STEP_SIZE = 2.0;
 

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -992,7 +992,7 @@ public class Controller {
         return intersectingStateIcons;
     }
 
-    private Point2d getCenterOfStateIcons(Set<Entity> entities) {
+    private Point2d getCenterOfStateIcons(Set<? extends Entity> entities) {
         Point2d centerPosition = new Point2d();
 
         for (Entity entity : entities ) {
@@ -1002,7 +1002,7 @@ public class Controller {
         return centerPosition;
     }
 
-    private void separateStateIcons(Set<Entity> entities) {
+    private void separateStateIcons(Set<? extends Entity> entities) {
         final double STEP_SIZE = 2.0;
 
         if (entities.isEmpty()) {

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -892,9 +892,12 @@ public class Controller {
     private boolean doStateIconsIntersect(Entity first, Entity second) {
         final double STATE_ICON_RADIUS_INCLUDING_MARGIN = 20.0;
 
-        double x = Math.pow(first.position.x - second.position.x, 2) + Math.pow(first.position.y - second.position.y, 2);
+        double centerDistance = Math.sqrt(
+                Math.pow(first.position.x - second.position.x, 2) + Math.pow(first.position.y - second.position.y, 2)
+        );
 
-        return x <= Math.pow(STATE_ICON_RADIUS_INCLUDING_MARGIN * 2, 2);
+        // Icons intersect or touching each-other?
+        return centerDistance <= STATE_ICON_RADIUS_INCLUDING_MARGIN * 2;
     }
 
     private boolean doesStateIconIntersectWithSet(Entity entity, Set<Entity> entities) {

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -12,14 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import javax.imageio.ImageIO;
 import javax.media.j3d.Transform3D;

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -87,6 +87,7 @@ public class Controller {
     private String outputRendersDirectoryName;
     private String outputFloorplanDirectoryName;
     private boolean useExistingRenders;
+    private int stateIconMargin = 10;
 
     private class Entity {
         public String name;
@@ -96,6 +97,7 @@ public class Controller {
         public String title;
         public boolean alwaysOn;
         public boolean isRgb;
+        public double radius = 20;
 
         public Entity(String name, Point2d position, EntityDisplayType defaultDisplayType, EntityTapAction defaultTapAction, String title) {
             this.name = name;
@@ -890,14 +892,12 @@ public class Controller {
     }
 
     private boolean doStateIconsIntersect(Entity first, Entity second) {
-        final double STATE_ICON_RADIUS_INCLUDING_MARGIN = 20.0;
-
         double centerDistance = Math.sqrt(
                 Math.pow(first.position.x - second.position.x, 2) + Math.pow(first.position.y - second.position.y, 2)
         );
 
         // Icons intersect or touching each-other?
-        return centerDistance <= STATE_ICON_RADIUS_INCLUDING_MARGIN * 2;
+        return centerDistance <= first.radius + second.radius + stateIconMargin;
     }
 
     private boolean doesStateIconIntersectWithSet(Entity entity, Set<Entity> entities) {

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -103,6 +103,56 @@ public class Controller {
         }
     }
 
+    private class ClusterEntity extends Entity {
+        private final Set<Entity> entities;
+
+        public ClusterEntity(Set<Entity> entities) {
+            super("cluster", new Point2d(), EntityDisplayType.NONE, EntityTapAction.NONE, null);
+            this.entities = entities;
+            this.position = getCenterOfStateIcons(entities);
+            this.distributeClusterEntities();
+            this.radius *= Math.min(entities.size(), 3);
+        }
+
+        private void distributeClusterEntities() {
+            if (this.entities.size() < 2) {
+                return;
+            }
+
+            final double STEP_SIZE = 1;
+
+            int originalMargin = stateIconMargin;
+            stateIconMargin = 1;
+
+            int index = 0;
+            for (Entity entity : this.entities) {
+                entity.position = new Point2d(this.position);
+
+                if (index++ == 0) {
+                    continue;
+                }
+
+                double angle = index * Math.PI / ((double) (this.entities.size() - 1) / 2);
+                Vector2d direction = new Vector2d(Math.cos(angle), Math.sin(angle));
+
+                direction.normalize();
+                direction.scale(STEP_SIZE);
+                while (stateIconWithWhichStateIconIntersects(entity, this.entities) != null) {
+                    entity.position.add(direction);
+                }
+            }
+
+            if (this.entities.size() == 2) {
+                for (Entity entity : this.entities) {
+                    entity.position.x -= entity.radius;
+                }
+                this.position = getCenterOfStateIcons(this.entities);
+            }
+
+            stateIconMargin = originalMargin;
+        }
+    }
+
     public Controller(Home home) {
         this.home = home;
         settings = new Settings(home);

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -948,11 +948,11 @@ public class Controller {
     }
 
     private Point2d getCenterOfStateIcons(Set<Entity> entities) {
-        Point2d centerPostition = new Point2d();
+        Point2d centerPosition = new Point2d();
         for (Entity entity : entities )
-            centerPostition.add(entity.position);
-        centerPostition.scale(1.0 / entities.size());
-        return centerPostition;
+            centerPosition.add(entity.position);
+        centerPosition.scale(1.0 / entities.size());
+        return centerPosition;
     }
 
     private void separateStateIcons(Set<Entity> entities) {

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -1067,12 +1067,17 @@ public class Controller {
     }
 
     private void moveEntityIconsToAvoidIntersection() {
+        List<ClusterEntity> clusters = clusterEntities(homeAssistantEntities.values());
+
         for (int i = 0; i < 100; i++) {
-            List<Set<Entity>> intersectingStateIcons = findIntersectingStateIcons();
-            if (intersectingStateIcons.isEmpty())
+            List<Set<Entity>> intersectingStateIcons = findIntersectingStateIcons(clusters);
+            if (intersectingStateIcons.isEmpty()) {
                 break;
-            for (Set<Entity> set : intersectingStateIcons)
+            }
+
+            for (Set<Entity> set : intersectingStateIcons) {
                 separateStateIcons(set);
+            }
         }
     }
-};
+}

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -930,9 +930,9 @@ public class Controller {
         List<Set<Entity>> intersectingStateIcons = new ArrayList<Set<Entity>>();
 
         for (Entity entity : homeAssistantEntities.values()) {
-            Set<Entity> interectingSet = setWithWhichStateIconIntersects(entity, intersectingStateIcons);
-            if (interectingSet != null) {
-                interectingSet.add(entity);
+            Set<Entity> intersectingSet = setWithWhichStateIconIntersects(entity, intersectingStateIcons);
+            if (intersectingSet != null) {
+                intersectingSet.add(entity);
                 continue;
             }
             Entity intersectingStateIcon = stateIconWithWhichStateIconIntersects(entity);


### PR DESCRIPTION
### Description

Entities with the same position ended up with position `(NaN, NaN)`, placing them in the bottom-left corner of the image. This PR fixes `(NaN, NaN)` position along with some refactoring of typos and statements for clarification.

### How Has This Been Tested?

1. Having a SH3D file with multiple furniture (with a entity-name) at _**exactly**_ the same position.
2. Run the tool with exactly the same configuration before and after the changes.
3. Compare the position of the entities before and after the changes.

### Checklist

* [x] I have tested and built the changes locally and they work as expected
* [x] I have added relevant documentation or updated existing documentation
* [x] My changes generate no new warnings

### Screenshots (if applicable)

Before:
![image](https://github.com/user-attachments/assets/7be0a9b1-e66a-4eed-b0ba-06e225950c22)

After:
![image](https://github.com/user-attachments/assets/1f1fddcd-fa13-49ff-9b85-cbf069f80fb7)


### Additional Context

Please see the individual commit messages for more info.

The position which is stored in an entity's properties may fractionally differ from the position set in SH3D.
E.g. `(1, 1)` in SH3D may be `(0.99, 1.01)` in the properties.

This means, although entities are in the same position in SH3D, their position differ in the script. This is fixed by rounding the x and y values to their nearest integer value.