### PR TITLE
Add clustering of entities

### DIFF
--- a/src/com/shmuelzon/HomeAssistantFloorPlan/CircleCenterPositioner.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/CircleCenterPositioner.java
@@ -1,0 +1,213 @@
+// Copyright (c) 2025, Ferry Cools
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package com.shmuelzon.HomeAssistantFloorPlan;
+
+import javax.vecmath.Point2d;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A utility class for generating predefined geometric patterns of points which represent the center position of a
+ * circle.
+ */
+public class CircleCenterPositioner {
+    private static final double SQRT_3 = Math.sqrt(3);
+
+    /**
+     * Generates a predefined geometric pattern of points which represent the center position of a circle.
+     * The arrangements are centered at the given 'center' point.
+     * The y-axis is inverted after the initial arrangement calculations.
+     *
+     * @param circleCount    The number of circles to arrange (1-7 inclusive).
+     * @param circleDiameter The diameter of each circle.
+     * @param center         The center point for the arrangement.
+     * @param margin         The margin (gap) between the edges of the circles.
+     * @return A list of Point2d objects representing the center positions of the arranged circles.
+     * @throws IllegalArgumentException If the number of circles is not between 1 and 7 (inclusive), the diameter is not
+     *                                  positive, or the margin is negative.
+     */
+    public static List<Point2d> generatePositions(int circleCount, double circleDiameter, Point2d center, double margin) {
+        if (circleCount < 1 || circleCount > 7 || circleDiameter <= 0 || margin < 0) {
+            throw new IllegalArgumentException(
+                "Value of circleCount must be between 1 and 7 (inclusive), diameter must be positive, and margin must be non-negative."
+            );
+        }
+
+        double effectiveDiameter = circleDiameter + margin;
+
+        List<Point2d> circlePositions = new ArrayList<>();
+
+        switch (circleCount) {
+            case 1:
+                circlePositions.add(new Point2d(0, 0));
+                break;
+            case 2:
+                circlePositions.addAll(
+                    Arrays.asList(new Point2d(-effectiveDiameter / 2, 0), new Point2d(effectiveDiameter / 2, 0))
+                );
+                break;
+            case 3:
+                circlePositions.addAll(createTriangle3(effectiveDiameter));
+                break;
+            case 4:
+                circlePositions.addAll(createSquare(effectiveDiameter));
+                break;
+            case 5:
+                circlePositions.addAll(createTrapezoid5Isosceles(effectiveDiameter));
+                break;
+            case 6:
+                circlePositions.addAll(createTriangle6(effectiveDiameter));
+                break;
+            case 7:
+                circlePositions.addAll(createCentralPlusSurrounding(effectiveDiameter, circleCount));
+                break;
+            default:
+                throw new IllegalStateException("Unexpected number of circles: " + circleCount);
+        }
+
+        for (Point2d position : circlePositions) {
+            position.y = -position.y;
+            position.add(center);
+        }
+
+        return circlePositions;
+    }
+
+    /**
+     * Creates a triangular arrangement of three circles.
+     *
+     * @param diameter The diameter of each circle.
+     * @return A list of Point2d objects representing the center positions of the circles.
+     */
+    private static List<Point2d> createTriangle3(double diameter) {
+        double height = (diameter * SQRT_3) / 2;
+
+        return Arrays.asList(
+            new Point2d(0, -height / 2),
+            new Point2d(-diameter / 2, height / 2),
+            new Point2d(diameter / 2, height / 2)
+        );
+    }
+
+    /**
+     * Creates a triangular arrangement of six circles.
+     *
+     * @param diameter The diameter of each circle.
+     * @return A list of Point2d objects representing the center positions of the circles.
+     */
+    private static List<Point2d> createTriangle6(double diameter) {
+        double height = (diameter * SQRT_3) / 2;
+
+        return Arrays.asList(
+            new Point2d(-diameter, -height),
+            new Point2d(0, -height),
+            new Point2d(diameter, -height),
+            new Point2d(-diameter / 2, 0),
+            new Point2d(diameter / 2, 0),
+            new Point2d(0, height)
+        );
+    }
+
+    /**
+     * Creates a square arrangement of four circles.
+     *
+     * @param diameter The diameter of each circle.
+     * @return A list of Point2d objects representing the center positions of the circles.
+     */
+    private static List<Point2d> createSquare(double diameter) {
+        return Arrays.asList(
+            new Point2d(-diameter / 2, -diameter / 2),
+            new Point2d(diameter / 2, -diameter / 2),
+            new Point2d(diameter / 2, diameter / 2),
+            new Point2d(-diameter / 2, diameter / 2)
+        );
+    }
+
+    /**
+     * Creates an isosceles trapezoid arrangement of 5 circles.
+     *
+     * @param diameter The diameter of each circle.
+     * @return A list of Point2d objects representing the center positions of the circles.
+     */
+    private static List<Point2d> createTrapezoid5Isosceles(double diameter) {
+        double verticalOffset = (diameter / 2) * SQRT_3;
+
+        return Arrays.asList(
+            new Point2d(-diameter, 0),
+            new Point2d(0, 0),
+            new Point2d(diameter, 0),
+            new Point2d(-diameter / 2, verticalOffset),
+            new Point2d(diameter / 2, verticalOffset)
+        );
+    }
+
+    /**
+     * Creates an arrangement of circles with one circle in the center and the others surrounding it.
+     *
+     * @param diameter   The diameter of each circle.
+     * @param circleCount The number of circles.
+     * @return A list of Point2d objects representing the center positions of the circles.
+     */
+    private static List<Point2d> createCentralPlusSurrounding(double diameter, int circleCount) {
+        if (circleCount > 7) {
+            System.err.println(
+                "Warning: Number of circles requested ("
+                + circleCount
+                + ") is greater than the maximum supported (7). The arrangement might be unexpected."
+            );
+        }
+
+        List<Point2d> points = new ArrayList<>();
+        points.add(new Point2d(0, 0));
+
+        for (int i = 0; i < circleCount - 1; i++) {
+            double angle = 2 * Math.PI * i / (circleCount - 1);
+            points.add(new Point2d(diameter * Math.cos(angle), diameter * Math.sin(angle)));
+        }
+
+        return points;
+    }
+
+    public static void main(String[] args) {
+        Point2d center = new Point2d(5, 10);
+        double diameter = 5;
+        double margin = 1;
+
+        for (int i = 1; i <= 7; i++) {
+            List<Point2d> positions = generatePositions(i, diameter, center, margin);
+            System.out.println("Having a center position at " + center.x + ", " + center.y + "...");
+            System.out.println("The center positions for " + i + " distributed circles are:");
+            for (int j = 0; j < positions.size(); j++) {
+                System.out.println("Circle " + (j + 1) + ": " + positions.get(j));
+            }
+            System.out.println();
+        }
+    }
+}

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -1235,10 +1235,16 @@ public class Controller {
     private void separateStateIcons(Set<Entity> entities) {
         final double STEP_SIZE = 2.0;
 
-        Point2d centerPostition = getCenterOfStateIcons(entities);
+        Point2d centerPosition = getCenterOfStateIcons(entities);
+        Set<Entity> movedEntities = new HashSet<>();
 
         for (Entity entity : entities) {
-            Vector2d direction = new Vector2d(entity.position.x - centerPostition.x, entity.position.y - centerPostition.y);
+            if (movedEntities.contains(entity)) {
+                continue;
+            }
+
+            Vector2d direction = new Vector2d(entity.position.x - centerPosition.x, entity.position.y - centerPosition.y);
+            Cluster parentCluster = entityToClusterMap.get(entity);
 
             if (direction.length() == 0) {
                 double[] randomRepeatableDirection = { entity.id.hashCode(), entity.name.hashCode() };
@@ -1247,6 +1253,22 @@ public class Controller {
 
             direction.normalize();
             direction.scale(STEP_SIZE);
+
+            if (parentCluster != null) {
+                double degrees = 0;
+
+                do {
+                    parentCluster.rotate(++degrees);
+                } while (degrees < 360 && parentCluster.doesIntersectWith(entities));
+
+                if (degrees >= 360) {
+                    parentCluster.move(direction);
+                }
+
+                movedEntities.addAll(parentCluster.entities);
+                continue;
+            }
+
             entity.move(direction);
         }
     }
@@ -1260,4 +1282,4 @@ public class Controller {
                 separateStateIcons(set);
         }
     }
-};
+}

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -1141,11 +1141,9 @@ public class Controller {
     }
 
     private boolean doStateIconsIntersect(Entity first, Entity second) {
-        final double STATE_ICON_RAIDUS_INCLUDING_MARGIN = 25.0;
-
         double x = Math.pow(first.position.x - second.position.x, 2) + Math.pow(first.position.y - second.position.y, 2);
 
-        return x <= Math.pow(STATE_ICON_RAIDUS_INCLUDING_MARGIN * 2, 2);
+        return x <= Math.pow(STATE_ICON_DIAMETER + stateIconMargin, 2);
     }
 
     private boolean doesStateIconIntersectWithSet(Entity entity, Set<Entity> entities) {

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -13,6 +13,7 @@ import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -27,13 +28,8 @@ import javax.vecmath.Point2d;
 import javax.vecmath.Vector2d;
 import javax.vecmath.Vector4d;
 
-import com.eteks.sweethome3d.j3d.AbstractPhotoRenderer;
-import com.eteks.sweethome3d.model.Camera;
-import com.eteks.sweethome3d.model.Home;
-import com.eteks.sweethome3d.model.HomeFurnitureGroup;
-import com.eteks.sweethome3d.model.HomeLight;
-import com.eteks.sweethome3d.model.HomePieceOfFurniture;
-import com.eteks.sweethome3d.model.Room;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 
 public class Controller {
@@ -158,6 +154,23 @@ public class Controller {
         lightsPower = getLightsPower(lights);
         homeAssistantEntities = new HashMap<String, Entity>();
         generateHomeAssistantEntities();
+    }
+
+    private static List<Set<Entity>> splitEntityList(List<Entity> entities, int setSize) {
+        if (entities == null || entities.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        if (setSize <= 0) {
+            throw new IllegalArgumentException("Set-size must be positive.");
+        }
+
+        return IntStream.range(0, (entities.size() + setSize - 1) / setSize)
+                        .mapToObj(i -> entities.stream()
+                                               .skip((long) i * setSize)
+                                               .limit(setSize)
+                                               .collect(Collectors.toSet()))
+                        .collect(Collectors.toList());
     }
 
     public void loadDefaultSettings() {

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -1,12 +1,24 @@
 package com.shmuelzon.HomeAssistantFloorPlan;
 
+import com.eteks.sweethome3d.j3d.AbstractPhotoRenderer;
+import com.eteks.sweethome3d.model.Camera;
+import com.eteks.sweethome3d.model.Home;
+import com.eteks.sweethome3d.model.HomeFurnitureGroup;
+import com.eteks.sweethome3d.model.HomeLight;
+import com.eteks.sweethome3d.model.HomePieceOfFurniture;
+import com.eteks.sweethome3d.model.Room;
+
+import javax.imageio.ImageIO;
+import javax.media.j3d.Transform3D;
+import javax.vecmath.Point2d;
+import javax.vecmath.Vector2d;
+import javax.vecmath.Vector4d;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.io.IOException;
-import java.lang.InterruptedException;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -23,11 +35,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import javax.imageio.ImageIO;
-import javax.media.j3d.Transform3D;
-import javax.vecmath.Point2d;
-import javax.vecmath.Vector2d;
-import javax.vecmath.Vector4d;
 
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;


### PR DESCRIPTION
### Description
This change will create clusters of max. 7 entities.

A cluster contains entities which originally had the same position, but by clustering, their position will be distributed around this original position by applying a geometric pattern.

When separating overlapping entities, if it belongs to a cluster, the cluster (including its child-entities) is moved/rotated instead to keep it as close as possible to its current position.

### How Has This Been Tested?

The change is tested by using the changed plugin in SH3D 7.5 with bundled OpenJDK 11.0.18 - 64bit.

### Checklist

* [x] I have tested and built the changes locally and they work as expected
* [ ] I have added relevant documentation or updated existing documentation
* [x] My changes generate no new warnings

> [!NOTE]
> ATTOW this comment, this PR is a draft.
> It doesn't take the stationary entities into account yet, since this feature is added after I've started this feature.
> Also, the documentation might have to be updated to clarify the clustering of entities.
> 
> Please try the clustering feature. Any feedback is kindly appreciated.