### PR TITLE
add more options for when to display icons/badges

### DIFF
--- a/src/com/shmuelzon/HomeAssistantFloorPlan/ApplicationPlugin.properties
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/ApplicationPlugin.properties
@@ -54,11 +54,16 @@ HomeAssistantFloorPlan.Panel.displayTypeLabel.text=Display type:
 HomeAssistantFloorPlan.Panel.displayTypeComboBox.BADGE.text=Badge
 HomeAssistantFloorPlan.Panel.displayTypeComboBox.ICON.text=Icon
 HomeAssistantFloorPlan.Panel.displayTypeComboBox.LABEL.text=Label
-HomeAssistantFloorPlan.Panel.displayConditionLabel.text=Display condition:
-HomeAssistantFloorPlan.Panel.displayConditionComboBox.ALWAYS.text=Always
-HomeAssistantFloorPlan.Panel.displayConditionComboBox.NEVER.text=Never
-HomeAssistantFloorPlan.Panel.displayConditionComboBox.WHEN_ON.text=When on
-HomeAssistantFloorPlan.Panel.displayConditionComboBox.WHEN_OFF.text=When off
+HomeAssistantFloorPlan.Panel.displayStateLabel.text=Display when state:
+
+# --- NEW: Text for the operator dropdown ---
+HomeAssistantFloorPlan.Panel.displayOperatorComboBox.IS.text=is
+HomeAssistantFloorPlan.Panel.displayOperatorComboBox.IS_NOT.text=is not
+HomeAssistantFloorPlan.Panel.displayOperatorComboBox.GREATER_THAN.text=>
+HomeAssistantFloorPlan.Panel.displayOperatorComboBox.LESS_THAN.text=<
+HomeAssistantFloorPlan.Panel.displayOperatorComboBox.ALWAYS.text=Always
+HomeAssistantFloorPlan.Panel.displayOperatorComboBox.NEVER.text=Never
+
 HomeAssistantFloorPlan.Panel.tapActionLabel.text=Tap action:
 HomeAssistantFloorPlan.Panel.doubleTapActionLabel.text=Double tap action:
 HomeAssistantFloorPlan.Panel.holdActionLabel.text=Hold action:
@@ -74,9 +79,6 @@ HomeAssistantFloorPlan.Panel.backgroundColorLabel.text=Background color:
 HomeAssistantFloorPlan.Panel.alwaysOnLabel.text=Always on:
 HomeAssistantFloorPlan.Panel.isRgbLabel.text=Is RGB(W)/dimmable light:
 HomeAssistantFloorPlan.Panel.displayFurnitureConditionLabel.text=Display furniture:
-HomeAssistantFloorPlan.Panel.displayFurnitureConditionComboBox.ALWAYS.text=Always
-HomeAssistantFloorPlan.Panel.displayFurnitureConditionComboBox.STATE_EQUALS.text=State is...
-HomeAssistantFloorPlan.Panel.displayFurnitureConditionComboBox.STATE_NOT_EQUALS.text=State isn't...
 
 HomeAssistantFloorPlan.Panel.attributes.alwaysOn.text=always on
 HomeAssistantFloorPlan.Panel.attributes.isRgb.text=RGB/dimmable
@@ -86,3 +88,28 @@ HomeAssistantFloorPlan.Panel.closeButton.text=Close
 HomeAssistantFloorPlan.Panel.startButton.text=Start
 HomeAssistantFloorPlan.Panel.stopButton.text=Stop
 HomeAssistantFloorPlan.Panel.resetToDefaultsButton.text=Reset to defaults
+
+# --- Suggested states for entity domains ---
+entity.states.air_quality=good,moderate,unhealthy for sensitive groups,unhealthy,very unhealthy,hazardous
+entity.states.alarm_control_panel=disarmed,armed_home,armed_away,armed_night,armed_vacation,pending,arming,disarming,triggered
+entity.states.assist_satellite=idle,listening,processing,responding
+entity.states.binary_sensor=on,off
+entity.states.camera=streaming,recording,idle
+entity.states.climate=off,heat,cool,heat_cool,auto,dry,fan_only
+entity.states.cover=open,closed,opening,closing
+entity.states.device_tracker=home,not_home
+entity.states.fan=on,off
+entity.states.humidifier=on,off
+entity.states.input_boolean=on,off
+entity.states.lawn_mower=docked,mowing,paused,returning,error
+entity.states.light=on,off
+entity.states.lock=locked,unlocked,locking,unlocking
+entity.states.media_player=playing,paused,idle,off,standby,on
+entity.states.remote=on,off
+entity.states.siren=on,off
+entity.states.switch=on,off
+entity.states.update=on,off
+entity.states.vacuum=docked,cleaning,paused,returning,error
+entity.states.valve=open,closed
+entity.states.water_heater=off,eco,electric,performance,high_demand,heat_pump
+entity.states.weather=sunny,cloudy,partlycloudy,windy,rainy,snowy,fog,hail,lightning


### PR DESCRIPTION
Fixes #148

### Description

New Feature:  Add the ability to more accurately specify when to display entities and furniture.  The original project only supported "on" or "off", but now it supports common values for each domain type.  E.g. cover entities show "open", "closed", "opening", etc.

### How Has This Been Tested?

This was manually tested.  Verify with several use cases: 
1) test ALWAYS
2) test NEVER
3) test each type of sensor (cover, binary, sensor, etc)
4) test "IS"
5) test "IS_NOT"
6) test ">" and "<"

### Checklist

* [ x] I have tested and built the changes locally and they work as expected
* [ x] I have added relevant documentation or updated existing documentation
* [ x] My changes generate no new warnings

### Screenshots (if applicable)


### Additional Context

