### PR TITLE
Add base folder setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ the room they're located in. Please verify the list matches your expectations.
 * Sensitivity - [1, 100] The degree by which two pixels need to be different
   from one another to be taken into account for the generated overlay image.
   Only relevant for "room overlay" light mixing mode and RGB lights
+* Base path - The path where the floorplan images will be saved in Home Assistant.
+  By default this value is `/local/floorplan`.
 * Output directory - The location on your PC where the floor plan images and
   YAML will be saved
 

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/ApplicationPlugin.properties
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/ApplicationPlugin.properties
@@ -44,6 +44,8 @@ HomeAssistantFloorPlan.Panel.imageFormatLabel.text=Image format:
 HomeAssistantFloorPlan.Panel.imageFormatComboBox.PNG.text=PNG
 HomeAssistantFloorPlan.Panel.imageFormatComboBox.JPEG.text=JPEG
 
+HomeAssistantFloorPlan.Panel.baseFolderLabel.text=HA Base folder:
+
 HomeAssistantFloorPlan.Panel.outputDirectoryLabel.text=Output directory:
 HomeAssistantFloorPlan.Panel.outputDirectory.title=Choose floor-plan output directory
 HomeAssistantFloorPlan.Panel.browseButton.text=Browse...

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Controller.java
@@ -60,6 +60,7 @@ public class Controller {
     private static final String CONTROLLER_QUALITY = "quality";
     private static final String CONTROLLER_IMAGE_FORMAT = "imageFormat";
     private static final String CONTROLLER_RENDER_TIME = "renderTime";
+    private static final String CONTROLLER_BASE_FOLDER_NAME = "baseFolderName";
     private static final String CONTROLLER_OUTPUT_DIRECTORY_NAME = "outputDirectoryName";
     private static final String CONTROLLER_USE_EXISTING_RENDERS = "useExistingRenders";
 
@@ -83,6 +84,7 @@ public class Controller {
     private Quality quality;
     private ImageFormat imageFormat;
     private List<Long> renderDateTimes;
+    private String baseFolderName;
     private String outputDirectoryName;
     private String outputRendersDirectoryName;
     private String outputFloorplanDirectoryName;
@@ -111,6 +113,7 @@ public class Controller {
         quality = Quality.valueOf(settings.get(CONTROLLER_QUALITY, Quality.HIGH.name()));
         imageFormat = ImageFormat.valueOf(settings.get(CONTROLLER_IMAGE_FORMAT, ImageFormat.PNG.name()));
         renderDateTimes = settings.getListLong(CONTROLLER_RENDER_TIME, Arrays.asList(camera.getTime()));
+        baseFolderName = settings.get(CONTROLLER_BASE_FOLDER_NAME, "/local/floorplan");
         outputDirectoryName = settings.get(CONTROLLER_OUTPUT_DIRECTORY_NAME, System.getProperty("user.home"));
         outputRendersDirectoryName = outputDirectoryName + File.separator + "renders";
         outputFloorplanDirectoryName = outputDirectoryName + File.separator + "floorplan";
@@ -199,6 +202,15 @@ public class Controller {
         propertyChangeSupport.firePropertyChange(Property.NUMBER_OF_RENDERS.name(), oldNumberOfTotaleRenders, getNumberOfTotalRenders());
     }
 
+    public String getBaseFolder() {
+        return baseFolderName;
+    }
+
+    public void setBaseFolder(String baseFolderName) {
+        this.baseFolderName = baseFolderName;
+        settings.set(CONTROLLER_BASE_FOLDER_NAME, baseFolderName);
+    }
+
     public String getOutputDirectory() {
         return outputDirectoryName;
     }
@@ -278,7 +290,7 @@ public class Controller {
             generateTransparentImage(outputFloorplanDirectoryName + File.separator + TRANSPARENT_IMAGE_NAME + ".png");
             String yaml = String.format(
                 "type: picture-elements\n" +
-                "image: /local/floorplan/%s.png?version=%s\n" +
+                "image: " + this.baseFolderName + "/%s.png?version=%s\n" +
                 "elements:\n", TRANSPARENT_IMAGE_NAME, renderHash(TRANSPARENT_IMAGE_NAME, true));
             
             turnOffLightsFromOtherLevels();
@@ -675,7 +687,7 @@ public class Controller {
             "          action: none\n" +
             "        hold_action:\n" +
             "          action: none\n" +
-            "        image: /local/floorplan/%s.%s?version=%s\n" +
+            "        image: " + this.baseFolderName + "/%s.%s?version=%s\n" +
             "        filter: none\n" +
             "        style:\n" +
             "          left: 50%%\n" +
@@ -710,8 +722,8 @@ public class Controller {
             "          type: image\n" +
             "          image: >-\n" +
             "              ${!isInColoredMode(COLOR_MODE) || (isInColoredMode(COLOR_MODE) && LIGHT_COLOR && LIGHT_COLOR[0] == 0 && LIGHT_COLOR[1] == 0) ?\n" +
-            "              '/local/floorplan/%s.png?version=%s' :\n" +
-            "              '/local/floorplan/%s.png?version=%s' }\n" +
+            "              '" + this.baseFolderName + "/%s.png?version=%s' :\n" +
+            "              '" + this.baseFolderName + "/%s.png?version=%s' }\n" +
             "        style:\n" +
             "          filter: '${ \"hue-rotate(\" + (isInColoredMode(COLOR_MODE) && LIGHT_COLOR ? LIGHT_COLOR[0] : 0) + \"deg) saturate(\" + (LIGHT_COLOR ? LIGHT_COLOR[1] / 100 : 1) + \")\"}'\n" +
             "          opacity: '${LIGHT_STATE === ''on'' ? (BRIGHTNESS / 255) : ''100''}'\n" +

--- a/src/com/shmuelzon/HomeAssistantFloorPlan/Panel.java
+++ b/src/com/shmuelzon/HomeAssistantFloorPlan/Panel.java
@@ -98,6 +98,8 @@ public class Panel extends JPanel implements DialogView {
     private JComboBox<Controller.Renderer> rendererComboBox;
     private JLabel qualityLabel;
     private JComboBox<Controller.Quality> qualityComboBox;
+    private JLabel baseFolderLabel;
+    private JTextField baseFolderTextField;
     private JLabel outputDirectoryLabel;
     private JTextField outputDirectoryTextField;
     private JLabel renderTimeLabel;
@@ -469,6 +471,17 @@ public class Panel extends JPanel implements DialogView {
             }
         });
 
+        baseFolderLabel = new JLabel();
+        baseFolderLabel.setText(resource.getString("HomeAssistantFloorPlan.Panel.baseFolderLabel.text"));
+        baseFolderTextField = new JTextField(20);
+        baseFolderTextField.setText(controller.getBaseFolder());
+        baseFolderTextField.getDocument().addDocumentListener(new SimpleDocumentListener() {
+            @Override
+            public void executeUpdate(DocumentEvent e) {
+                controller.setBaseFolder(baseFolderTextField.getText());
+            }
+        });
+
         outputDirectoryLabel = new JLabel();
         outputDirectoryLabel.setText(resource.getString("HomeAssistantFloorPlan.Panel.outputDirectoryLabel.text"));
         outputDirectoryTextField = new JTextField(20);
@@ -526,6 +539,7 @@ public class Panel extends JPanel implements DialogView {
         nightRenderCheckbox.setEnabled(enabled);
         nightRenderTimeSpinner.setEnabled(enabled);
         imageFormatComboBox.setEnabled(enabled);
+        baseFolderTextField.setEnabled(enabled);
         outputDirectoryTextField.setEnabled(enabled);
         outputDirectoryBrowseButton.setEnabled(enabled);
         useExistingRendersCheckbox.setEnabled(enabled);
@@ -634,6 +648,15 @@ public class Panel extends JPanel implements DialogView {
             GridBagConstraints.HORIZONTAL, insets, 0, 0));
         add(sensitivitySpinner, new GridBagConstraints(
             1, currentGridYIndex, 1, 1, 0, 0, GridBagConstraints.CENTER,
+            GridBagConstraints.HORIZONTAL, insets, 0, 0));
+        currentGridYIndex++;
+
+        /* Base folder */
+        add(baseFolderLabel, new GridBagConstraints(
+            0, currentGridYIndex, 1, 1, 0, 0, GridBagConstraints.CENTER,
+            GridBagConstraints.HORIZONTAL, insets, 0, 0));
+        add(baseFolderTextField, new GridBagConstraints(
+            1, currentGridYIndex, 2, 1, 0, 0, GridBagConstraints.CENTER,
             GridBagConstraints.HORIZONTAL, insets, 0, 0));
         currentGridYIndex++;
 


### PR DESCRIPTION
### Description

This PR adds a setting to modify the base Home Assistant folder from `/local/floorplan`. This will make it easier for users that have multiple floors in their house. Previously, the `floorplan.yaml` output file had to be modified by hand (or script).

### How Has This Been Tested?

This was tested locally against SweetHome3D 7.5.

### Checklist

* [X] I have tested and built the changes locally and they work as expected
* [X] I have added relevant documentation or updated existing documentation
* [X] My changes generate no new warnings

### Screenshots (if applicable)

<img width="625" height="673" alt="image" src="https://github.com/user-attachments/assets/6cbb62c7-384f-4f42-93dc-3c6ecee72e64" />

### Additional Context

